### PR TITLE
created new post endpoint for memeory recall

### DIFF
--- a/core/cat/memory/vector_memory_collection.py
+++ b/core/cat/memory/vector_memory_collection.py
@@ -19,6 +19,10 @@ from cat.db.vector_database import get_vector_db
 from cat.log import log
 from cat.memory.utils import DocumentRecall, to_document_recall
 
+#from langchain.docstore.document import Document
+from langchain_core.documents import Document
+
+
 
 class VectorMemoryCollection:
     def __init__(self, agent_id: str, collection_name: str):
@@ -36,22 +40,44 @@ class VectorMemoryCollection:
 
     def _tenant_field_condition(self) -> FieldCondition:
         return FieldCondition(key="tenant_id", match=MatchValue(value=self.agent_id))
+    
+    
 
     # adapted from https://github.com/langchain-ai/langchain/blob/bfc12a4a7644cfc4d832cc4023086a7a5374f46a/libs/langchain/langchain/vectorstores/qdrant.py#L1941
     # see also https://github.com/langchain-ai/langchain/blob/bfc12a4a7644cfc4d832cc4023086a7a5374f46a/libs/langchain/langchain/vectorstores/qdrant.py#L1965
     def _build_condition(self, key: str, value: Any) -> List[FieldCondition]:
         out = []
 
-        if isinstance(value, Dict):
-            out.extend(self._build_condition(f"{key}.{k}", v) for k, v in value.items())
-        elif isinstance(value, List):
-            out.extend(
-                self._build_condition(f"{key}[]" if isinstance(v, Dict) else f"{key}", v) for v in value
-            )
+        if isinstance(value, dict):
+            for _key, value in value.items():
+                out.extend(self._build_condition(f"{key}.{_key}", value))
+        elif isinstance(value, list):
+            for _value in value:
+                if isinstance(_value, dict):
+                    out.extend(self._build_condition(f"{key}[]", _value))
+                else:
+                    out.extend(self._build_condition(f"{key}", _value))
         else:
-            out.append(FieldCondition(key=f"metadata.{key}", match=MatchValue(value=value)))
+            out.append(
+                FieldCondition(
+                    key=f"metadata.{key}",
+                    match=MatchValue(value=value),
+                )
+            )
 
         return out
+    
+    def _qdrant_filter_from_dict(self, filter: dict) -> Filter:
+        if not filter or len(filter)<1:
+            return None
+
+        return Filter(
+            must=[
+                condition
+                for key, value in filter.items()
+                for condition in self._build_condition(key, value)
+            ]
+        )
 
     def get_payload_indexes(self) -> Dict:
         """
@@ -167,41 +193,15 @@ class VectorMemoryCollection:
         )
         return res
 
-    # retrieve similar memories from embedding
     def recall_memories_from_embedding(
-        self, embedding: List[float], metadata: Dict | None = None, k: int | None = 5, threshold: float | None = None
-    ) -> List[DocumentRecall]:
-        """
-        Retrieve memories from the collection based on an embedding vector. The memories are sorted by similarity to the
-        embedding vector. The metadata filter is applied to the memories before retrieving them. The number of memories
-        to retrieve is limited by the k parameter. The threshold parameter is used to filter out memories with a score
-        below the threshold. The memories are returned as a list of tuples, where each tuple contains a Document, the
-        similarity score, and the embedding vector of the memory. The Document contains the page content and metadata of
-        the memory. The similarity score is a float between 0 and 1, where 1 is the highest similarity. The embedding
-        vector is a list of floats. The list of tuples is sorted by similarity score in descending order. If the k
-        parameter is None, all memories are retrieved. If the threshold parameter is None, no memories are filtered out.
+        self, embedding, metadata=None, k=5, threshold=None
+    ):
+        """Retrieve similar memories from embedding"""
 
-        Args:
-            embedding: Embedding vector.
-            metadata: Dictionary containing metadata filter.
-            k: Number of memories to retrieve.
-            threshold: Similarity threshold.
-
-        Returns:
-            List: List of DocumentRecall.
-        """
-
-        conditions = [self._tenant_field_condition()]
-        if metadata:
-            conditions.extend([
-                condition for key, value in metadata.items() for condition in self._build_condition(key, value)
-            ])
-
-        # retrieve memories
         memories = self.client.search(
             collection_name=self.collection_name,
             query_vector=embedding,
-            query_filter=Filter(must=conditions),
+            query_filter=self._qdrant_filter_from_dict(metadata),
             with_payload=True,
             with_vectors=True,
             limit=k,
@@ -215,8 +215,26 @@ class VectorMemoryCollection:
             ),
         )
 
-        # convert Qdrant points to a structure containing langchain.Document and its information
-        return [to_document_recall(m) for m in memories]
+        # convert Qdrant points to langchain.Document
+        langchain_documents_from_points = []
+        for m in memories:
+            langchain_documents_from_points.append(
+                (
+                    Document(
+                        page_content=m.payload.get("page_content"),
+                        metadata=m.payload.get("metadata") or {},
+                    ),
+                    m.score,
+                    m.vector,
+                    m.id,
+                )
+            )
+
+        # we'll move out of langchain conventions soon and have our own cat Document
+        # for doc, score, vector in langchain_documents_from_points:
+        #    doc.lc_kwargs = None
+
+        return langchain_documents_from_points
 
     def recall_all_memories(self) -> List[DocumentRecall]:
         """

--- a/core/cat/memory/vector_memory_collection.py
+++ b/core/cat/memory/vector_memory_collection.py
@@ -66,6 +66,7 @@ class VectorMemoryCollection:
             )
 
         return out
+
     
     def _qdrant_filter_from_dict(self, filter: dict) -> Filter:
         if not filter or len(filter)<1:

--- a/core/cat/routes/embedder.py
+++ b/core/cat/routes/embedder.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, Query
 
 from cat.auth.connection import AdminConnectionAuth
 from cat.auth.permissions import AdminAuthResource, AuthPermission
@@ -9,6 +9,11 @@ from cat.factory.base_factory import ReplacedNLPConfig
 from cat.factory.embedder import EmbedderFactory
 from cat.looking_glass.bill_the_lizard import BillTheLizard
 from cat.routes.routes_utils import GetSettingsResponse, GetSettingResponse, UpsertSettingResponse
+
+from cat.auth.connection import HTTPAuth, ContextualCats
+from cat.auth.permissions import AuthPermission, AuthResource
+from .memory.points import RecallResponseQuery
+
 
 router = APIRouter()
 
@@ -74,3 +79,19 @@ async def upsert_embedder_setting(
         raise CustomValidationException(f"{embedder_name} not supported. Must be one of {allowed_configurations}")
 
     return await lizard.replace_embedder(embedder_name, payload)
+
+@router.get("/embedding", response_model=RecallResponseQuery)
+async def get_embedding(
+    text: str = Query(..., title="Text to embed"),
+    ccats : ContextualCats = Depends(HTTPAuth(AdminAuthResource.EMBEDDER, AuthPermission.READ))
+) -> RecallResponseQuery:
+    """Get the embedding of the query"""
+    ccat = ccats.cheshire_cat
+    embedder = ccat.embedder
+    response = RecallResponseQuery(
+        text=text,
+        vector=embedder.embed_query(text)
+    )
+    return response
+
+

--- a/core/cat/routes/memory/points.py
+++ b/core/cat/routes/memory/points.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Any
 from pydantic import BaseModel
-from fastapi import Query, APIRouter, Depends, Body
+from fastapi import Query, APIRouter, Depends, Body, Request
 from qdrant_client.http.models import UpdateResult, Record
 
 from cat.auth.connection import HTTPAuth, ContextualCats

--- a/core/cat/routes/memory/points.py
+++ b/core/cat/routes/memory/points.py
@@ -178,14 +178,12 @@ async def recall_memory_points(
     }
 
     # Loop over collections and retrieve nearby memories
-    collections = list(
-        VectorMemoryCollectionTypes
-    )
+    collections = [VectorMemoryCollectionTypes.EPISODIC, VectorMemoryCollectionTypes.DECLARATIVE, VectorMemoryCollectionTypes.PROCEDURAL]
     recalled = {}
     for c in collections:
         # only episodic collection has users
         user_id = cats.stray_cat.user.id
-        if c == "episodic":
+        if c == VectorMemoryCollectionTypes.EPISODIC:
             metadata["source"] = user_id
         else:
             metadata.pop("source", None)


### PR DESCRIPTION
This pull request introduces several changes to the `core/cat/routes/memory/points.py` file, focusing on enhancing the recall functionality and updating the API routes. The most important changes include adding a new POST route for recalling memory points with metadata criteria, marking an existing GET route as deprecated, and updating imports to include `Body`.

Enhancements to recall functionality:

* Added a new POST route `/recall` to allow recalling memory points with specified metadata criteria. This includes handling the request body, embedding the query, and retrieving nearby memories based on the metadata.

API route updates:

* Marked the existing GET route `/recall` as deprecated.

Import updates:

* Updated imports to include `Body` from `fastapi` to handle the request body in the new POST route.